### PR TITLE
convenience find and replace action

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,17 @@
+name: 'Porter KV Replace Action'
+description: 'Replace keys with values in a given file'
+
+inputs:
+  key_values:
+    description: 'Comma-separated key-value pairs'
+    required: true
+  file_path:
+    description: 'Path to the file to be modified'
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Modify file if needed
+      shell: bash
+      run: replace.sh '${{ inputs.key_values }}' "${{ inputs.file_path }}"

--- a/replace.sh
+++ b/replace.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+# Check if at least two arguments are given (# of arguments is $#)
+if [ $# -lt 2 ]; then
+    echo "Usage: $0 'key1=value1,key2=value2,...' filename"
+    exit 1
+fi
+
+# The first argument is the comma-separated key-value pairs
+kv_pairs=$1
+
+# The second argument is the filename
+filename=$2
+
+# Check if the file exists
+if [ ! -f "$filename" ]; then
+    echo "Error: File '$filename' not found."
+    exit 1
+fi
+
+# Convert the comma-separated list into an array
+IFS=',' read -r -a pairs <<< "$kv_pairs"
+
+# Iterate over each key-value pair
+for pair in "${pairs[@]}"; do
+    # Split the pair into key and value
+    IFS='=' read -r key value <<< "$pair"
+
+    # Use sed to replace the key with the value in the file
+    sed -i "s/$key/$value/g" "$filename"
+done
+
+echo "Replacement completed."


### PR DESCRIPTION
This is a utility action for replacing values at a provided file path.

We used to support string interpolation in porter.yaml, which was useful for setting env vars that needed to be referenced from other services or from values provided by CI. This allows us to achieve similar functionality for users in the short term.

In the long term, the plan will be to implement more formal methods for referencing values emitted by other apps and addons in porter.yaml.

Example of how this might be used:

```yaml
 - name: Find and replace
    uses: ./.github/actions/replace
    with:
      key_values: $IMAGE_TAG=${{ github.sha }}
      file_path: ./porter_image_test.yml
```

```yaml
---
version: v2
services:
  - name: web
    port: 3000

image:
  tag: $IMAGE_TAG
```
  