### PR TITLE
Update replace.sh

### DIFF
--- a/replace.sh
+++ b/replace.sh
@@ -27,7 +27,7 @@ for pair in "${pairs[@]}"; do
     IFS='=' read -r key value <<< "$pair"
 
     # Use sed to replace the key with the value in the file
-    sed -i "s/$key/$value/g" "$filename"
+    sed -i "s|$key|$value|g" "$filename"
 done
 
 echo "Replacement completed."


### PR DESCRIPTION
for replacing certain variables, like in the case of a database url, the string will include `/`, which sed is interpreting as a command when using this `sed -i "s/$key/$value/g"`

switching sed to use a less common character `sed -i "s|$key|$value|g" "$filename"`

ref: https://backreference.org/2010/02/20/using-different-delimiters-in-sed/index.html